### PR TITLE
COMP: Fix extension packaging updating project name to match extension name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
-project(SlicerVirtualCursor)
+project(SlicerVirtualMouseCursor)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
This commit is expected to fix the following error:

```
CMake Error at /work/Preview/Slicer-0/Extensions/CMake/SlicerFunctionExtractExtensionDescription.cmake:135 (message):
  error: EXTENSION_FILE CMake variable points to a inexistent file or
  directory:
  /.../SlicerVirtualMouseCursor-build/./SlicerVirtualCursor.json
Call Stack (most recent call first):
  /work/Preview/Slicer-0/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake:206 (slicerFunctionExtractExtensionDescriptionFromJson)
```